### PR TITLE
Fixes potion key default from 'keyp' => 'keyP'

### DIFF
--- a/static/inputmap.json
+++ b/static/inputmap.json
@@ -30,7 +30,7 @@
   "shop-food": ["KeyF"],
   "shop-candle": ["KeyC"],
   "shop-ring": ["KeyZ"],
-  "misc-potion": ["Keyp"],
+  "misc-potion": ["KeyP"],
   "misc-gamble": ["KeyG"],
   "misc-hints": ["KeyH"],
   "misc-sword": ["KeyS"],


### PR DESCRIPTION
Minor bugfix fixing typo in default key for potions.