### PR TITLE
Feature inputmap tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "vue": "^2.3.3",
     "vue-electron": "^1.0.6",
     "vue-router": "^2.5.3",
+    "vue-tabs-component": "^1.4.0",
     "vuex": "^2.3.1",
     "vuex-persistedstate": "^2.4.2",
     "vuex-router-sync": "^5.0.0"

--- a/src/renderer/components/InputMap.vue
+++ b/src/renderer/components/InputMap.vue
@@ -5,19 +5,49 @@
     router-link.esc.flex.column.align-center(to="/")
       .fa.fa-times-circle-o.fa-lg
       div ESC
-    table.binding-table.mb-20
-      thead
-        tr
-          th Input
-          th Binding #1
-          th Binding #2
-          th Binding #3
-      tbody
-        tr(v-for="(input, k) in inputmap")
-          td {{k}}
-          td(v-on:dblclick="mapInput(k, 0)") {{input[0]}}
-          td(v-on:dblclick="mapInput(k, 1)") {{input[1]}}
-          td(v-on:dblclick="mapInput(k, 2)") {{input[2]}}
+  tabs
+    tab(name="Global")
+      table.binding-table.mb-20
+        thead
+          tr
+            th Input
+            th Binding #1
+            th Binding #2
+            th Binding #3
+        tbody
+          tr(v-for="(input, k) in inputmap['global']")
+            td {{k}}
+            td(v-on:dblclick="mapInput('global', k, 0)") {{input[0]}}
+            td(v-on:dblclick="mapInput('global', k, 1)") {{input[1]}}
+            td(v-on:dblclick="mapInput('global', k, 2)") {{input[2]}}
+    tab(name="Overworld")
+      table.binding-table.mb-20
+        thead
+          tr
+            th Input
+            th Binding #1
+            th Binding #2
+            th Binding #3
+        tbody
+          tr(v-for="(input, k) in inputmap['overworld']")
+            td {{k}}
+            td(v-on:dblclick="mapInput('overworld', k, 0)") {{input[0]}}
+            td(v-on:dblclick="mapInput('overworld', k, 1)") {{input[1]}}
+            td(v-on:dblclick="mapInput('overworld', k, 2)") {{input[2]}}
+    tab(name="Dungeon")
+      table.binding-table.mb-20
+        thead
+          tr
+            th Input
+            th Binding #1
+            th Binding #2
+            th Binding #3
+        tbody
+          tr(v-for="(input, k) in inputmap['dungeon']")
+            td {{k}}
+            td(v-on:dblclick="mapInput('dungeon', k, 0)") {{input[0]}}
+            td(v-on:dblclick="mapInput('dungeon', k, 1)") {{input[1]}}
+            td(v-on:dblclick="mapInput('dungeon', k, 2)") {{input[2]}}
   .binding-overlay(v-if="isBinding")
     p Press any key, esc to cancel, backspace to clear
     p ({{pressedKeys.join('+')}})
@@ -49,8 +79,9 @@ export default {
     }
   },
   methods: {
-    mapInput (name, index) {
+    mapInput (type, name, index) {
       this.isBinding = true
+      this.bindingType = type
       this.bindingInputName = name
       this.bindingIndex = index
     },
@@ -66,12 +97,12 @@ export default {
           return
         }
         let pressed = this.$game.input.getPressedKeys()
-        
+
         pressed.forEach(k => {
           if (!this.pressedKeys.includes(k.code)) {
             this.pressedKeys.push(k.code)
           }
-        });
+        })
         if (this.pressedKeys.some(x => this.$game.input.isKeyUp(x))) {
           this.assignCurrentInput()
         }
@@ -84,6 +115,7 @@ export default {
     },
     assignCurrentInput () {
       this.$store.commit('ASSIGN_INPUT', {
+        type: this.bindingType,
         name: this.bindingInputName,
         index: this.bindingIndex,
         input: this.pressedKeys.join("+")
@@ -95,6 +127,61 @@ export default {
 }
 </script>
 
+<style lang="sass">
+.tabs-component
+  margin: 10px 0
+
+.tabs-component-tabs
+  border: solid 1px #ddd
+  border-radius: 6px
+  margin-bottom: 5px
+
+@media (min-width: 700px)
+  .tabs-component-tabs
+    border: 0
+    align-items: stretch
+    display: flex
+    justify-content: flex-start
+    margin-bottom: -1px
+
+.tabs-component-tab
+  color: #999
+  font-size: 16px
+  font-weight: 600
+  margin-right: 0
+  list-style: none
+  padding: 0 5px 0 5px
+
+.tabs-component-tab:not(:last-child)
+  border-bottom: dotted 1px #ddd
+
+.tabs-component-tab:hover
+  color: #666
+
+.tabs-component-tab.is-active
+  color: #000
+
+.tabs-component-tab.is-disabled *
+  color: #cdcdcd
+  cursor: not-allowed !important
+
+@media (min-width: 700px)
+  .tabs-component-tab
+    background-color: #fff
+    border: solid 1px #ddd
+    border-radius: 3px 3px 0 0
+    margin-right: .5em
+    transform: translateY(2px)
+    transition: transform .3s ease
+
+  .tabs-component-tab.is-active
+    border-bottom: solid 1px #fff
+    z-index: 2
+    transform: translateY(0)
+
+  .tabs-component-panels
+    padding: 10px 0
+</style>
 <style lang="sass" scoped>
 .config-screen
   font-family: 'Rubik', sans-serif
@@ -106,12 +193,12 @@ export default {
   right: 25px
   top: 30px
 
-table 
+table
   border-collapse: collapse
   width: 95%
   margin: auto
 
-th, td 
+th, td
   padding: 0.25rem
   text-align: left
   border: 1px solid black
@@ -119,7 +206,7 @@ th, td
 td:hover
   background-color: #455371
 
-tbody tr:nth-child(odd) 
+tbody tr:nth-child(odd)
   background: #3f3f3f
 
 
@@ -156,7 +243,7 @@ tbody tr:nth-child(odd)
   display: flex
   align-items: center
   justify-content: center
-  
+
   .marker-icon
     height: 100%
     width: 100%

--- a/src/renderer/components/InputMap.vue
+++ b/src/renderer/components/InputMap.vue
@@ -128,6 +128,7 @@ export default {
 </script>
 
 <style lang="sass">
+/* This CSS is to handle tabbed panels, should be moved elsewhere
 .tabs-component
   margin: 10px 0
 
@@ -136,7 +137,7 @@ export default {
   border-radius: 6px
   margin-bottom: 5px
 
-@media (min-width: 700px)
+@media (min-width: 400px)
   .tabs-component-tabs
     border: 0
     align-items: stretch
@@ -151,6 +152,7 @@ export default {
   margin-right: 0
   list-style: none
   padding: 0 5px 0 5px
+  background-color: #fff
 
 .tabs-component-tab:not(:last-child)
   border-bottom: dotted 1px #ddd
@@ -165,7 +167,7 @@ export default {
   color: #cdcdcd
   cursor: not-allowed !important
 
-@media (min-width: 700px)
+@media (min-width: 400px)
   .tabs-component-tab
     background-color: #fff
     border: solid 1px #ddd

--- a/src/renderer/components/TrackerDungeon.vue
+++ b/src/renderer/components/TrackerDungeon.vue
@@ -112,7 +112,7 @@ export default {
     handleMarkerInput () {
       let { r, c } = this.selected
       let room = this.getCell(r, c)
-      if (this.isBindingDown('cycle-wall-left')) {
+      if (this.isBindingDown('dungeon', 'cycle-wall-left')) {
         let wall = this.getCell(r, c - 1)
         if (wall) {
           this.cycleWall(wall, 1)
@@ -121,7 +121,7 @@ export default {
           }
         }
       }
-      if (this.isBindingDown('cycle-wall-right')) {
+      if (this.isBindingDown('dungeon', 'cycle-wall-right')) {
         let wall = this.getCell(r, c + 1)
         if (wall) {
           this.cycleWall(wall, 1)
@@ -130,7 +130,7 @@ export default {
           }
         }
       }
-      if (this.isBindingDown('cycle-wall-up')) {
+      if (this.isBindingDown('dungeon', 'cycle-wall-up')) {
         let wall = this.getCell(r - 1, c)
         if (wall) {
           this.cycleWall(wall, 1)
@@ -139,7 +139,7 @@ export default {
           }
         }
       }
-      if (this.isBindingDown('cycle-wall-down')) {
+      if (this.isBindingDown('dungeon', 'cycle-wall-down')) {
         let wall = this.getCell(r + 1, c)
         if (wall) {
           this.cycleWall(wall, 1)
@@ -148,25 +148,25 @@ export default {
           }
         }
       }
-      if (this.isBindingDown('cycle-room-up')) {
+      if (this.isBindingDown('dungeon', 'cycle-room-up')) {
         let room = this.getCell(r, c)
         this.cycleRoom(room, 1)
-      } else if (this.isBindingDown('cycle-room-down')) {
+      } else if (this.isBindingDown('dungeon', 'cycle-room-down')) {
         let room = this.getCell(r, c)
         this.cycleRoom(room, -1)
       }
     },
     handleSelectorMovement () {
-      if (this.isBindingDown('selector-up')) {
+      if (this.isBindingDown('global', 'selector-up')) {
         this.selected.r = Math.max(0, this.selected.r - 2)
       }
-      if (this.isBindingDown('selector-down')) {
+      if (this.isBindingDown('global', 'selector-down')) {
         this.selected.r = Math.min(14, this.selected.r + 2)
       }
-      if (this.isBindingDown('selector-left')) {
+      if (this.isBindingDown('global', 'selector-left')) {
         this.selected.c = Math.max(0, this.selected.c - 2)
       }
-      if (this.isBindingDown('selector-right')) {
+      if (this.isBindingDown('global', 'selector-right')) {
         this.selected.c = Math.min(14, this.selected.c + 2)
       }
     },

--- a/src/renderer/components/TrackerMap.vue
+++ b/src/renderer/components/TrackerMap.vue
@@ -104,37 +104,37 @@ export default {
       this.handleMarkerInput()
     },
     handleSelectorMovement () {
-      if (this.isBindingDown('selector-up')) {
+      if (this.isBindingDown('global', 'selector-up')) {
         this.moveSelector(-16)
       }
-      if (this.isBindingDown('selector-down')) {
+      if (this.isBindingDown('global', 'selector-down')) {
         this.moveSelector(16)
       }
-      if (this.isBindingDown('selector-left')) {
+      if (this.isBindingDown('global', 'selector-left')) {
         this.moveSelector(-1)
       }
-      if (this.isBindingDown('selector-right')) {
+      if (this.isBindingDown('global', 'selector-right')) {
         this.moveSelector(1)
       }
     },
     handleMarkerInput () {
-      if (this.isBindingDown('cycle-level')) {
+      if (this.isBindingDown('overworld', 'cycle-level')) {
         this.cycleGroup('dungeon')
       }
-      if (this.isBindingDown('cycle-shop')) {
+      if (this.isBindingDown('overworld', 'cycle-shop')) {
         this.cycleGroup('shop')
       }
-      if (this.isBindingDown('cycle-misc')) {
+      if (this.isBindingDown('overworld', 'cycle-misc')) {
         this.cycleGroup('misc')
       }
-      if (this.isBindingDown('cycle-warp')) {
+      if (this.isBindingDown('overworld', 'cycle-warp')) {
         this.cycleGroup('warp')
       }
-      if (this.isBindingDown('clear-marker')) {
+      if (this.isBindingDown('overworld', 'clear-marker')) {
         this.clearMarker()
       } else {
         Object.keys(this.markers).forEach(m => {
-          if (this.isBindingDown(m)) {
+          if (this.isBindingDown('overworld', m)) {
             this.$store.commit("SET_TILE_MARKER", { tile: this.selectedTile, marker: m })
           }
         })

--- a/src/renderer/components/TrackerMap.vue
+++ b/src/renderer/components/TrackerMap.vue
@@ -134,7 +134,8 @@ export default {
         this.clearMarker()
       } else {
         Object.keys(this.markers).forEach(m => {
-          if (this.isBindingDown('overworld', m)) {
+          let type = m.startsWith('level-') ? 'global' : 'overworld'
+          if (this.isBindingDown(type, m)) {
             this.$store.commit("SET_TILE_MARKER", { tile: this.selectedTile, marker: m })
           }
         })

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import {Tabs, Tab} from 'vue-tabs-component';
 import axios from 'axios'
 import 'font-awesome/css/font-awesome'
 import App from './App'
@@ -11,6 +12,8 @@ Vue.http = Vue.prototype.$http = axios
 Vue.config.productionTip = false
 const unsync = sync(store, router)
 Vue.use(VueGame)
+Vue.component('tabs', Tabs);
+Vue.component('tab', Tab);
 /* eslint-disable no-new */
 let v = new Vue({
   components: { App },

--- a/src/renderer/store/modules/Input.js
+++ b/src/renderer/store/modules/Input.js
@@ -1,14 +1,6 @@
-import inputmap from '../../../../static/inputmap.json'
 import gameState from '../../../Game'
 
-let storedInput = localStorage.getItem('inputmap')
-if (storedInput) {
-  storedInput = JSON.parse(storedInput)
-} else {
-  storedInput = inputmap
-}
-storedInput = Object.assign(inputmap, storedInput)
-
+let storedInput = getStoredInput()
 
 const state = {
   inputmap: storedInput,
@@ -35,4 +27,10 @@ export default {
   state,
   mutations,
   getters
+}
+
+function getStoredInput() {
+  let inputmap = require('../../../../static/inputmap.json')
+  let storedInput = localStorage.getItem('inputmap') || {}
+  return Object.assign(inputmap, storedInput)
 }

--- a/src/renderer/store/modules/Input.js
+++ b/src/renderer/store/modules/Input.js
@@ -7,19 +7,19 @@ const state = {
 }
 const mutations = {
   ASSIGN_INPUT (state, d) {
-    state.inputmap[d.name][d.index] = d.input
-    localStorage.setItem('inputmap', JSON.stringify(state.inputmap))
+    state.inputmap[d.type][d.name][d.index] = d.input
+    localStorage.setItem('inputmap_v1', JSON.stringify(state.inputmap))
   }
 }
 const getters = {
-  isBindingPressed: state => (binding) => {
-    return state.inputmap[binding] && state.inputmap[binding].some(x => gameState.input.isKeyPressed(x))
+  isBindingPressed: state => (type, binding) => {
+    return state.inputmap[type][binding] && state.inputmap[type][binding].some(x => gameState.input.isKeyPressed(x))
   },
-  isBindingDown: state => (binding) => {
-    return state.inputmap[binding] && state.inputmap[binding].some(x => gameState.input.isKeyDown(x))
+  isBindingDown: state => (type, binding) => {
+    return state.inputmap[type][binding] && state.inputmap[type][binding].some(x => gameState.input.isKeyDown(x))
   },
-  isBindingUp: state => (binding) => {
-    return state.inputmap[binding] && state.inputmap[binding].some(x => gameState.input.isKeyUp(x))
+  isBindingUp: state => (type, binding) => {
+    return state.inputmap[type][binding] && state.inputmap[type][binding].some(x => gameState.input.isKeyUp(x))
   }
 }
 
@@ -30,7 +30,113 @@ export default {
 }
 
 function getStoredInput() {
-  let inputmap = require('../../../../static/inputmap.json')
-  let storedInput = localStorage.getItem('inputmap') || {}
-  return Object.assign(inputmap, storedInput)
+  let storedInput = loadStoredInputData()
+  let storedInputVersion = storedInput.version || 0
+  let storedInputMaps = [
+    mapV0ToV1
+  ]
+
+  while (storedInputVersion < storedInputMaps.length) {
+    storedInput = storedInputMaps[storedInputVersion](storedInput)
+    storedInputVersion = storedInput.version
+    localStorage.setItem('inputmap_v' + storedInputVersion, JSON.stringify(storedInput))
+  }
+
+  return storedInput
+}
+
+function loadStoredInputData() {
+  let storedInput
+
+  //Get Version 1
+  storedInput = localStorage.getItem('inputmap_v1')
+  storedInput = storedInput ? JSON.parse(storedInput) : null
+  if (storedInput === null) {
+    //Get Version 0
+    storedInput = localStorage.getItem('inputmap')
+    storedInput = storedInput ? JSON.parse(storedInput) : null
+  }
+  if (storedInput === null) {
+    //Get Default Data
+    storedInput = require('../../../../static/inputmap.json')
+  }
+
+  return Object.assign(storedInput)
+}
+
+function mapV0ToV1(storedInput) {
+  let globalInputs = getGlobalInputs();
+  let overworldInputs = getOverworldInputs();
+  let dungeonInputs = getDungeonInput();
+  let newStoredInput = {
+    global: {},
+    overworld: {},
+    dungeon: {}
+  }
+  for (let key in storedInput) {
+    if (globalInputs.includes(key)) {
+      newStoredInput['global'][key] = storedInput[key]
+    }
+    else if (overworldInputs.includes(key)) {
+      newStoredInput['overworld'][key] = storedInput[key]
+    }
+    else if (dungeonInputs.includes(key)) {
+      newStoredInput['dungeon'][key] = storedInput[key]
+    }
+  }
+  newStoredInput.version = 1
+
+  return newStoredInput
+}
+
+function getGlobalInputs() {
+  return [
+    "selector-up",
+    "selector-down",
+    "selector-left",
+    "selector-right"
+  ]
+}
+
+function getOverworldInputs() {
+  return [
+    "cycle-level",
+    "cycle-shop",
+    "cycle-misc",
+    "cycle-warp",
+    "level-1",
+    "level-2",
+    "level-3",
+    "level-4",
+    "level-5",
+    "level-6",
+    "level-7",
+    "level-8",
+    "level-9",
+    "shop-arrow",
+    "shop-bomb",
+    "shop-key",
+    "shop-food",
+    "shop-candle",
+    "shop-ring",
+    "misc-potion",
+    "misc-gamble",
+    "misc-hints",
+    "misc-sword",
+    "warp-1",
+    "warp-2",
+    "warp-3",
+    "warp-4"
+  ]
+}
+
+function getDungeonInput() {
+  return [
+    "cycle-wall-up",
+    "cycle-wall-down",
+    "cycle-wall-left",
+    "cycle-wall-right",
+    "cycle-room-up",
+    "cycle-room-down"
+  ]
 }

--- a/src/renderer/store/modules/Input.js
+++ b/src/renderer/store/modules/Input.js
@@ -109,6 +109,7 @@ function getGlobalInputs() {
 
 function getOverworldInputs() {
   return [
+    "clear-marker",
     "cycle-level",
     "cycle-shop",
     "cycle-misc",

--- a/src/renderer/store/modules/Input.js
+++ b/src/renderer/store/modules/Input.js
@@ -94,7 +94,16 @@ function getGlobalInputs() {
     "selector-up",
     "selector-down",
     "selector-left",
-    "selector-right"
+    "selector-right",
+    "level-1",
+    "level-2",
+    "level-3",
+    "level-4",
+    "level-5",
+    "level-6",
+    "level-7",
+    "level-8",
+    "level-9"
   ]
 }
 
@@ -104,15 +113,6 @@ function getOverworldInputs() {
     "cycle-shop",
     "cycle-misc",
     "cycle-warp",
-    "level-1",
-    "level-2",
-    "level-3",
-    "level-4",
-    "level-5",
-    "level-6",
-    "level-7",
-    "level-8",
-    "level-9",
     "shop-arrow",
     "shop-bomb",
     "shop-key",


### PR DESCRIPTION
This breaks up the inputmap into groupings (global, dungeon, and overworld).  In addition this adds tabbed panels to the config menu for inputmap.  Also adds inputmap versioning to allow for future refactoring.

With the intention of adding additional inputs and creating dynamic marker groupings later on, I felt the single long list of inputs was overwhelming and was getting confusing.  I also felt refactoring this system before implementing the above features would be easier then after the fact.

There is some CSS around the tabbed panels that I wasn't 100% sure where it should go (It's more of Global CSS).  Anyways, I wanted to share this branch to get feedback and suggestions on things like that, even if there are a few more commits needed to do everything in a clean manner.

NOTE: Your stored inputmap in localsession should not effected by this change, but with that being said it may be a good idea to back that up before running this branch.

NOTE: New inputmap is stored in `inputmap_v1` so reverting to an older branch will use the old storage location of just `inputmap`.  Also, the original `inputmap` data should automaticaly be ported to the `inputmap_v1` structure.